### PR TITLE
Add .wakatime-project file integration

### DIFF
--- a/com.vladfaust.unitywakatime/Editor/Plugin.cs
+++ b/com.vladfaust.unitywakatime/Editor/Plugin.cs
@@ -64,7 +64,7 @@ namespace WakaTime {
     }
 
     /// <summary>
-    /// Reads .wakatime-project
+    /// Reads .wakatime-project file
     /// <seealso cref="https://wakatime.com/faq#rename-projects"/> 
     /// </summary>
     /// <returns>Lines of .wakatime-project or null if file not found</returns>
@@ -72,7 +72,7 @@ namespace WakaTime {
       !File.Exists(WAKATIME_PROJECT_FILE) ? null : File.ReadAllLines(WAKATIME_PROJECT_FILE);
 
     /// <summary>
-    /// Rewrites o creates new .wakatime-project with given lines
+    /// Rewrites o creates new .wakatime-project file with given lines
     /// <seealso cref="https://wakatime.com/faq#rename-projects"/>
     /// </summary>
     /// <example>

--- a/com.vladfaust.unitywakatime/Editor/Plugin.cs
+++ b/com.vladfaust.unitywakatime/Editor/Plugin.cs
@@ -64,14 +64,8 @@ namespace WakaTime {
       LinkCallbacks();
     }
 
-    public static string[] GetProjectFile()
-    {
-      if (!File.Exists(WAKATIME_PROJECT_FILE)){
-        File.WriteAllLines(WAKATIME_PROJECT_FILE, new[] {Application.productName});
-      }
-
-      return File.ReadAllLines(WAKATIME_PROJECT_FILE);
-    }
+    public static string[] GetProjectFile() =>
+      !File.Exists(WAKATIME_PROJECT_FILE) ? null : File.ReadAllLines(WAKATIME_PROJECT_FILE);
 
     public static void SetProjectFile(string[] content)
     {

--- a/com.vladfaust.unitywakatime/Editor/Plugin.cs
+++ b/com.vladfaust.unitywakatime/Editor/Plugin.cs
@@ -8,7 +8,6 @@ using UnityEngine.Networking;
 using UnityEditor;
 using UnityEditor.Callbacks;
 using UnityEditor.SceneManagement;
-using System.Net;
 
 // Heavily inspired by https://github.com/bengsfort/WakaTime-Unity
 
@@ -65,13 +64,18 @@ namespace WakaTime {
       LinkCallbacks();
     }
 
-    public static void OpenProjectFile()
+    public static string[] GetProjectFile()
     {
       if (!File.Exists(WAKATIME_PROJECT_FILE)){
         File.WriteAllLines(WAKATIME_PROJECT_FILE, new[] {Application.productName});
       }
 
-      System.Diagnostics.Process.Start("notepad.exe", $"{WAKATIME_PROJECT_FILE}");
+      return File.ReadAllLines(WAKATIME_PROJECT_FILE);
+    }
+
+    public static void SetProjectFile(string[] content)
+    {
+      File.WriteAllLines(WAKATIME_PROJECT_FILE, content);
     }
 
     struct Response<T> {

--- a/com.vladfaust.unitywakatime/Editor/Plugin.cs
+++ b/com.vladfaust.unitywakatime/Editor/Plugin.cs
@@ -18,8 +18,10 @@ namespace WakaTime {
     public const string API_KEY_PREF = "WakaTime/APIKey";
     public const string ENABLED_PREF = "WakaTime/Enabled";
     public const string DEBUG_PREF = "WakaTime/Debug";
+    public static string PROJECT_NAME_PREF => $"WakaTime/ProjectName/{Application.productName}";
 
     private static string _apiKey = "";
+    private static string _projectName = "";
     private static bool _enabled = true;
     private static bool _debug = true;
 
@@ -47,6 +49,9 @@ namespace WakaTime {
       if (EditorPrefs.HasKey(API_KEY_PREF)) {
         _apiKey = EditorPrefs.GetString(API_KEY_PREF);
       }
+      
+      if (EditorPrefs.HasKey(PROJECT_NAME_PREF))
+        _projectName = EditorPrefs.GetString(PROJECT_NAME_PREF);
 
       if (_apiKey == string.Empty) {
         Debug.LogWarning("<WakaTime> API key is not set, skipping initialization...");
@@ -86,7 +91,7 @@ namespace WakaTime {
         entity = (file == string.Empty ? "Unsaved Scene" : file);
         type = "file";
         time = (float)(DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds;
-        project = Application.productName;
+        project = _projectName == string.Empty? Application.productName : _projectName;
         plugin = "unity-wakatime";
         branch = "master";
         language = "unity";

--- a/com.vladfaust.unitywakatime/Editor/ProjectEditWindow.cs
+++ b/com.vladfaust.unitywakatime/Editor/ProjectEditWindow.cs
@@ -5,39 +5,57 @@ namespace WakaTime
 {
     public class ProjectEditWindow : EditorWindow
     {
-        private static ProjectEditWindow window;
+        private static ProjectEditWindow _window;
         
-        private static readonly Vector2 size = new Vector2(400, 100);
-        private static readonly string[] projectSettings = {"", ""};
-    
+        private static readonly Vector2 Size = new Vector2(400, 138);
+        private static string[] _projectSettings;
+        private static string _branch;
+        private static readonly GUIStyle BranchStyle = new GUIStyle(EditorStyles.helpBox) {richText = true};
+        
         public static void Display()
         {
-            if (window)
+            if (_window)
             {
                 FocusWindowIfItsOpen<ProjectEditWindow>();
             }
             else
             {
-                window = CreateInstance<ProjectEditWindow>();
-                window.ShowUtility();
+                _window = CreateInstance<ProjectEditWindow>();
+                _window.ShowPopup();
             }
             
-            var pos = new Vector2(Screen.currentResolution.width, Screen.currentResolution.height) - size;
-            window.position = new Rect(pos/2, size);
-            window.titleContent = new GUIContent("Change project name");
-            Plugin.GetProjectFile().CopyTo(projectSettings, 0);
+            var pos = new Vector2(Screen.currentResolution.width, Screen.currentResolution.height) - Size;
+            _window.position = new Rect(pos/2, Size);
+            _window.titleContent = new GUIContent("Change project name");
+            
+            _projectSettings = new[] {"", ""};
+            Plugin.GetProjectFile().CopyTo(_projectSettings, 0);
+            _branch = string.IsNullOrEmpty(_projectSettings[1]) ? "<i>none</i>" : _projectSettings[1];
         }
-
+        
         void OnGUI()
         {
-            projectSettings[0] = EditorGUILayout.TextField("Project name",projectSettings[0]);
-            projectSettings[1] = EditorGUILayout.TextField("Current branch",projectSettings[1]);
-            
+            EditorGUILayout.LabelField("Overrides project name while sending to WakaTime. If empty, will be used Product Name from PlayerSettings", BranchStyle);
+            EditorGUILayout.BeginHorizontal();
+            {
+                EditorGUILayout.PrefixLabel("Project name");
+                _projectSettings[0] = EditorGUILayout.TextField(_projectSettings[0]);
+            }
+            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("Overrides branch name while sending to WakaTime. If empty, will be used current branch <i>(not implemented in this plugin yet)</i>", BranchStyle);
+            EditorGUILayout.BeginHorizontal();
+            {
+                EditorGUILayout.PrefixLabel("Current branch override");
+                EditorGUILayout.SelectableLabel(_branch, BranchStyle,
+                    GUILayout.Height(EditorGUIUtility.singleLineHeight));
+            }
+            EditorGUILayout.EndHorizontal();
             EditorGUILayout.BeginHorizontal();
             {
                 if (GUILayout.Button("Save"))
                 {
-                    Plugin.SetProjectFile(projectSettings);
+                    Plugin.SetProjectFile(_projectSettings);
                     Plugin.Initialize();
                     CloseAndNull();
                     FocusWindowIfItsOpen<Window>();
@@ -59,7 +77,7 @@ namespace WakaTime
         private void CloseAndNull()
         {
             Close();
-            window = null;
+            _window = null;
         }
     }
 }

--- a/com.vladfaust.unitywakatime/Editor/ProjectEditWindow.cs
+++ b/com.vladfaust.unitywakatime/Editor/ProjectEditWindow.cs
@@ -1,0 +1,65 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace WakaTime
+{
+    public class ProjectEditWindow : EditorWindow
+    {
+        private static ProjectEditWindow window;
+        
+        private static readonly Vector2 size = new Vector2(400, 100);
+        private static readonly string[] projectSettings = {"", ""};
+    
+        public static void Display()
+        {
+            if (window)
+            {
+                FocusWindowIfItsOpen<ProjectEditWindow>();
+            }
+            else
+            {
+                window = CreateInstance<ProjectEditWindow>();
+                window.ShowUtility();
+            }
+            
+            var pos = new Vector2(Screen.currentResolution.width, Screen.currentResolution.height) - size;
+            window.position = new Rect(pos/2, size);
+            window.titleContent = new GUIContent("Change project name");
+            Plugin.GetProjectFile().CopyTo(projectSettings, 0);
+        }
+
+        void OnGUI()
+        {
+            projectSettings[0] = EditorGUILayout.TextField("Project name",projectSettings[0]);
+            projectSettings[1] = EditorGUILayout.TextField("Current branch",projectSettings[1]);
+            
+            EditorGUILayout.BeginHorizontal();
+            {
+                if (GUILayout.Button("Save"))
+                {
+                    Plugin.SetProjectFile(projectSettings);
+                    Plugin.Initialize();
+                    CloseAndNull();
+                    FocusWindowIfItsOpen<Window>();
+                }
+
+                if (GUILayout.Button("Cancel"))
+                {
+                    CloseAndNull();
+                }
+            }
+            EditorGUILayout.EndHorizontal();
+        }
+
+        private void OnLostFocus()
+        {
+            CloseAndNull();
+        }
+
+        private void CloseAndNull()
+        {
+            Close();
+            window = null;
+        }
+    }
+}

--- a/com.vladfaust.unitywakatime/Editor/ProjectEditWindow.cs
+++ b/com.vladfaust.unitywakatime/Editor/ProjectEditWindow.cs
@@ -28,7 +28,7 @@ namespace WakaTime {
                 _window.ShowPopup();
             }
 
-            //We need only first 2 lines from .wakatime-project 
+            // We need only first 2 lines from .wakatime-project 
             _projectSettings = new[] {"", ""};
             var projectFile = Plugin.GetProjectFile();
 
@@ -40,48 +40,47 @@ namespace WakaTime {
             }
 
             _branch = string.IsNullOrEmpty(_projectSettings[1])
-                ? "" //TODO read current git branch
+                ? "" // TODO: Read current git branch
                 : _projectSettings[1]; 
 
-            //If we need to display "project file missing" line, we are making different height
-            //TODO calculate height dynamically, if path is too long buttons may not fit
+            // If we need to display "project file missing" line, we are making different height
+            // TODO: calculate height dynamically, if path is too long buttons may not fit
             _size.y = _isProjectFileMissed ? 170 : 138;
 
-            //Displaying in screen center
+            // Display at screen center
             var pos = new Vector2(Screen.currentResolution.width, Screen.currentResolution.height) - _size;
             _window.position = new Rect(pos / 2, _size);
             _window.titleContent = new GUIContent("Change project name");
         }
 
         void OnGUI() {
-            EditorGUILayout.LabelField(
-                "A project name to send to WakaTime (Product Name from Player Settings by default)", RichHelpBoxStyle);
             EditorGUILayout.BeginHorizontal(); {
                 EditorGUILayout.PrefixLabel("Project name");
                 _projectSettings[0] = EditorGUILayout.TextField(_projectSettings[0]);
             }
             EditorGUILayout.EndHorizontal();
-            EditorGUILayout.Space();
-
             EditorGUILayout.LabelField(
-                "A branch name to send to WakaTime (current git branch by default) <i>(not implemented in this plugin yet)</i>",
-                RichHelpBoxStyle);
+                "A project name to send to WakaTime (Product Name from Player Settings by default)", RichHelpBoxStyle);
+
             EditorGUILayout.BeginHorizontal(); {
-                EditorGUILayout.PrefixLabel("Current branch override");
+                EditorGUILayout.PrefixLabel("Branch");
                 EditorGUILayout.SelectableLabel(_branch, RichHelpBoxStyle,
                     GUILayout.Height(EditorGUIUtility.singleLineHeight));
             }
             EditorGUILayout.EndHorizontal();
+            EditorGUILayout.LabelField(
+                "A branch name to send to WakaTime (current git branch by default) <i>(not implemented in this plugin yet)</i>",
+                RichHelpBoxStyle);
 
             if (_isProjectFileMissed)
-                GUILayout.Label($"<b>{Path.GetFullPath(".wakatime_project")}</b> is missing. Press Save to create it",
+                GUILayout.Label($"<b>{Path.GetFullPath(".wakatime_project")}</b> will be created on save",
                     RichHelpBoxStyle);
             EditorGUILayout.BeginHorizontal(); {
                 if (GUILayout.Button("Save")) {
                     Plugin.SetProjectFile(_projectSettings);
                     Plugin.Initialize();
                     CloseAndNull();
-                    FocusWindowIfItsOpen<Window>(); //Updates main window for information redraw
+                    FocusWindowIfItsOpen<Window>(); // Updates main window for information redraw
                 }
 
                 if (GUILayout.Button("Cancel")) {

--- a/com.vladfaust.unitywakatime/Editor/ProjectEditWindow.cs
+++ b/com.vladfaust.unitywakatime/Editor/ProjectEditWindow.cs
@@ -2,95 +2,103 @@ using System.IO;
 using UnityEditor;
 using UnityEngine;
 
-namespace WakaTime
-{
-    public class ProjectEditWindow : EditorWindow
-    {
+namespace WakaTime {
+    /// <summary>
+    /// Popup window for editing .wakatime-project file
+    /// <seealso cref="https://wakatime.com/faq#rename-projects"/> 
+    /// </summary>
+    public class ProjectEditWindow : EditorWindow {
         private static ProjectEditWindow _window;
-        
+
         private static Vector2 _size = new Vector2(400, 138);
         private static string[] _projectSettings;
         private static string _branch;
-        private static readonly GUIStyle RichHelpBoxStyle = new GUIStyle(EditorStyles.helpBox) {richText = true};
+
+        private static readonly GUIStyle RichHelpBoxStyle
+            = new GUIStyle(EditorStyles.helpBox) {richText = true};
+
         private static bool _isProjectFileMissed;
 
-        public static void Display()
-        {
-            if (_window)
-            {
+        public static void Display() {
+            if (_window) {
                 FocusWindowIfItsOpen<ProjectEditWindow>();
             }
-            else
-            {
+            else {
                 _window = CreateInstance<ProjectEditWindow>();
                 _window.ShowPopup();
             }
 
-            var pos = new Vector2(Screen.currentResolution.width, Screen.currentResolution.height) - _size;
-            
-
+            //We need only first 2 lines from .wakatime-project 
             _projectSettings = new[] {"", ""};
             var projectFile = Plugin.GetProjectFile();
-            
+
             if (projectFile == null)
                 _isProjectFileMissed = true;
-            else
-            {
+            else {
                 _isProjectFileMissed = false;
                 projectFile.CopyTo(_projectSettings, 0);
             }
-            _branch = string.IsNullOrEmpty(_projectSettings[1]) ? "" : _projectSettings[1];
 
+            _branch = string.IsNullOrEmpty(_projectSettings[1])
+                ? "" //TODO read current git branch
+                : _projectSettings[1]; 
+
+            //If we need to display "project file missing" line, we are making different height
+            //TODO calculate height dynamically, if path is too long buttons may not fit
             _size.y = _isProjectFileMissed ? 170 : 138;
+
+            //Displaying in screen center
+            var pos = new Vector2(Screen.currentResolution.width, Screen.currentResolution.height) - _size;
             _window.position = new Rect(pos / 2, _size);
             _window.titleContent = new GUIContent("Change project name");
         }
 
-        void OnGUI()
-        {
-            EditorGUILayout.LabelField("A project name to send to WakaTime (Product Name from Player Settings by default)", RichHelpBoxStyle);
-            EditorGUILayout.BeginHorizontal();
-            {
+        void OnGUI() {
+            EditorGUILayout.LabelField(
+                "A project name to send to WakaTime (Product Name from Player Settings by default)", RichHelpBoxStyle);
+            EditorGUILayout.BeginHorizontal(); {
                 EditorGUILayout.PrefixLabel("Project name");
                 _projectSettings[0] = EditorGUILayout.TextField(_projectSettings[0]);
             }
             EditorGUILayout.EndHorizontal();
             EditorGUILayout.Space();
-            EditorGUILayout.LabelField("A branch name to send to WakaTime (current git branch by default) <i>(not implemented in this plugin yet)</i>", RichHelpBoxStyle);
-            EditorGUILayout.BeginHorizontal();
-            {
+
+            EditorGUILayout.LabelField(
+                "A branch name to send to WakaTime (current git branch by default) <i>(not implemented in this plugin yet)</i>",
+                RichHelpBoxStyle);
+            EditorGUILayout.BeginHorizontal(); {
                 EditorGUILayout.PrefixLabel("Current branch override");
                 EditorGUILayout.SelectableLabel(_branch, RichHelpBoxStyle,
                     GUILayout.Height(EditorGUIUtility.singleLineHeight));
             }
             EditorGUILayout.EndHorizontal();
+
             if (_isProjectFileMissed)
-                GUILayout.Label($"<b>{Path.GetFullPath(".wakatime_project")}</b> is missing. Press Save to create it", RichHelpBoxStyle);
-            EditorGUILayout.BeginHorizontal();
-            {
-                if (GUILayout.Button("Save"))
-                {
+                GUILayout.Label($"<b>{Path.GetFullPath(".wakatime_project")}</b> is missing. Press Save to create it",
+                    RichHelpBoxStyle);
+            EditorGUILayout.BeginHorizontal(); {
+                if (GUILayout.Button("Save")) {
                     Plugin.SetProjectFile(_projectSettings);
                     Plugin.Initialize();
                     CloseAndNull();
-                    FocusWindowIfItsOpen<Window>();
+                    FocusWindowIfItsOpen<Window>(); //Updates main window for information redraw
                 }
 
-                if (GUILayout.Button("Cancel"))
-                {
+                if (GUILayout.Button("Cancel")) {
                     CloseAndNull();
                 }
             }
             EditorGUILayout.EndHorizontal();
         }
 
-        private void OnLostFocus()
-        {
+        private void OnLostFocus() {
             CloseAndNull();
         }
 
-        private void CloseAndNull()
-        {
+        /// <summary>
+        /// Closes this window and erases instance
+        /// </summary>
+        private void CloseAndNull() {
             Close();
             _window = null;
         }

--- a/com.vladfaust.unitywakatime/Editor/Window.cs
+++ b/com.vladfaust.unitywakatime/Editor/Window.cs
@@ -23,7 +23,7 @@ namespace WakaTime {
     void OnGUI() {
       _enabled = EditorGUILayout.Toggle("Enable WakaTime", _enabled);
       _apiKey = EditorGUILayout.TextField("API key", _apiKey);
-      EditorGUILayout.LabelField("Project name:", _projectName);
+      EditorGUILayout.LabelField("Project name", _projectName);
       
       if (GUILayout.Button("Change project name"))
       {

--- a/com.vladfaust.unitywakatime/Editor/Window.cs
+++ b/com.vladfaust.unitywakatime/Editor/Window.cs
@@ -6,6 +6,7 @@ using UnityEditor;
 namespace WakaTime {
   public class Window : EditorWindow {
     private string _apiKey = "";
+    private string _projectName = "";
     private bool _enabled = true;
     private bool _debug = true;
 
@@ -20,12 +21,14 @@ namespace WakaTime {
     void OnGUI() {
       _enabled = EditorGUILayout.Toggle("Enable WakaTime", _enabled);
       _apiKey = EditorGUILayout.TextField("API key", _apiKey);
+      _projectName = EditorGUILayout.TextField("Override project name", _projectName);
       _debug = EditorGUILayout.Toggle("Debug", _debug);
 
       EditorGUILayout.BeginHorizontal();
 
       if (GUILayout.Button("Save Preferences")) {
         EditorPrefs.SetString(Plugin.API_KEY_PREF, _apiKey);
+        EditorPrefs.SetString(Plugin.PROJECT_NAME_PREF, _projectName);
         EditorPrefs.SetBool(Plugin.ENABLED_PREF, _enabled);
         EditorPrefs.SetBool(Plugin.DEBUG_PREF, _debug);
         Plugin.Initialize();
@@ -40,6 +43,8 @@ namespace WakaTime {
     void OnFocus() {
       if (EditorPrefs.HasKey(Plugin.API_KEY_PREF))
         _apiKey = EditorPrefs.GetString(Plugin.API_KEY_PREF);
+      if (EditorPrefs.HasKey(Plugin.PROJECT_NAME_PREF))
+        _projectName = EditorPrefs.GetString(Plugin.PROJECT_NAME_PREF);
       if (EditorPrefs.HasKey(Plugin.ENABLED_PREF))
         _enabled = EditorPrefs.GetBool(Plugin.ENABLED_PREF);
       if (EditorPrefs.HasKey(Plugin.DEBUG_PREF))

--- a/com.vladfaust.unitywakatime/Editor/Window.cs
+++ b/com.vladfaust.unitywakatime/Editor/Window.cs
@@ -10,25 +10,33 @@ namespace WakaTime {
     private bool _enabled = true;
     private bool _debug = true;
 
+    private bool _needToReload;
+
     const string DASHBOARD_URL = "https://wakatime.com/dashboard/";
 
     [MenuItem("Window/WakaTime")]
     static void Init() {
-      Window window = (Window)EditorWindow.GetWindow(typeof(Window), false, "WakaTime");
+      Window window = (Window)GetWindow(typeof(Window), false, "WakaTime");
       window.Show();
     }
 
     void OnGUI() {
       _enabled = EditorGUILayout.Toggle("Enable WakaTime", _enabled);
       _apiKey = EditorGUILayout.TextField("API key", _apiKey);
-      _projectName = EditorGUILayout.TextField("Override project name", _projectName);
+      EditorGUILayout.LabelField("Project name:", _projectName);
+      
+      if (GUILayout.Button("Change project name"))
+      {
+        Plugin.OpenProjectFile();
+        _needToReload = true;
+      }
+      
       _debug = EditorGUILayout.Toggle("Debug", _debug);
 
       EditorGUILayout.BeginHorizontal();
 
       if (GUILayout.Button("Save Preferences")) {
         EditorPrefs.SetString(Plugin.API_KEY_PREF, _apiKey);
-        EditorPrefs.SetString(Plugin.PROJECT_NAME_PREF, _projectName);
         EditorPrefs.SetBool(Plugin.ENABLED_PREF, _enabled);
         EditorPrefs.SetBool(Plugin.DEBUG_PREF, _debug);
         Plugin.Initialize();
@@ -41,14 +49,20 @@ namespace WakaTime {
     }
 
     void OnFocus() {
+      if (_needToReload)
+      {
+        Plugin.Initialize();
+        _needToReload = false;
+      }
+      
       if (EditorPrefs.HasKey(Plugin.API_KEY_PREF))
         _apiKey = EditorPrefs.GetString(Plugin.API_KEY_PREF);
-      if (EditorPrefs.HasKey(Plugin.PROJECT_NAME_PREF))
-        _projectName = EditorPrefs.GetString(Plugin.PROJECT_NAME_PREF);
       if (EditorPrefs.HasKey(Plugin.ENABLED_PREF))
         _enabled = EditorPrefs.GetBool(Plugin.ENABLED_PREF);
       if (EditorPrefs.HasKey(Plugin.DEBUG_PREF))
         _debug = EditorPrefs.GetBool(Plugin.DEBUG_PREF);
+
+      _projectName = Plugin.ProjectName;
     }
   }
 }

--- a/com.vladfaust.unitywakatime/Editor/Window.cs
+++ b/com.vladfaust.unitywakatime/Editor/Window.cs
@@ -27,7 +27,7 @@ namespace WakaTime {
       
       if (GUILayout.Button("Change project name"))
       {
-        Plugin.OpenProjectFile();
+        ProjectEditWindow.Display();
         _needToReload = true;
       }
       

--- a/com.vladfaust.unitywakatime/Editor/Window.cs
+++ b/com.vladfaust.unitywakatime/Editor/Window.cs
@@ -16,7 +16,7 @@ namespace WakaTime {
 
     [MenuItem("Window/WakaTime")]
     static void Init() {
-      Window window = (Window)GetWindow(typeof(Window), false, "WakaTime");
+      Window window = (Window) GetWindow(typeof(Window), false, "WakaTime");
       window.Show();
     }
 
@@ -24,13 +24,12 @@ namespace WakaTime {
       _enabled = EditorGUILayout.Toggle("Enable WakaTime", _enabled);
       _apiKey = EditorGUILayout.TextField("API key", _apiKey);
       EditorGUILayout.LabelField("Project name", _projectName);
-      
-      if (GUILayout.Button("Change project name"))
-      {
+
+      if (GUILayout.Button("Change project name")) {
         ProjectEditWindow.Display();
         _needToReload = true;
       }
-      
+
       _debug = EditorGUILayout.Toggle("Debug", _debug);
 
       EditorGUILayout.BeginHorizontal();
@@ -49,12 +48,11 @@ namespace WakaTime {
     }
 
     void OnFocus() {
-      if (_needToReload)
-      {
+      if (_needToReload) {
         Plugin.Initialize();
         _needToReload = false;
       }
-      
+
       if (EditorPrefs.HasKey(Plugin.API_KEY_PREF))
         _apiKey = EditorPrefs.GetString(Plugin.API_KEY_PREF);
       if (EditorPrefs.HasKey(Plugin.ENABLED_PREF))


### PR DESCRIPTION
It's useful if your product name differs from repository name. If you fill this field with repo name, you won't have to add custom rules in WakaTime settings to merge two projects into one