### PR TITLE
fix Obsolete warning for hierarchyWindowChanged

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,7 @@ The code has been successfuly tested with following Unity versions:
 * 2018.1.0b13
 * 2018.1.2f1
 * 2018.3.6f1
-
-## Known issues
-
-* Getting `'UnityEditor.EditorApplication.hierarchyWindowChanged' is obsolete: Use 'EditorApplication.hierarchyChanged'` warning on Unity 2018.x
+* 2018.3.10f1
 
 ## Installation using the Unity Package Manager (Unity 2018.1+)
 

--- a/com.vladfaust.unitywakatime/Editor/Plugin.cs
+++ b/com.vladfaust.unitywakatime/Editor/Plugin.cs
@@ -211,8 +211,12 @@ namespace WakaTime {
     static void LinkCallbacks(bool clean = false) {
       if (clean) {
         EditorApplication.playModeStateChanged -= OnPlaymodeStateChanged;
-        EditorApplication.contextualPropertyMenu -= OnPropertyContextMenu;
-        EditorApplication.hierarchyWindowChanged -= OnHierarchyWindowChanged;
+        EditorApplication.contextualPropertyMenu -= OnPropertyContextMenu;  
+        #if UNITY_2018_1_OR_NEWER
+          EditorApplication.hierarchyChanged -= OnHierarchyWindowChanged;
+        #else
+          EditorApplication.hierarchyWindowChanged -= OnHierarchyWindowChanged;
+        #endif  
         EditorSceneManager.sceneSaved -= OnSceneSaved;
         EditorSceneManager.sceneOpened -= OnSceneOpened;
         EditorSceneManager.sceneClosing -= OnSceneClosing;
@@ -221,7 +225,11 @@ namespace WakaTime {
 
       EditorApplication.playModeStateChanged += OnPlaymodeStateChanged;
       EditorApplication.contextualPropertyMenu += OnPropertyContextMenu;
-      EditorApplication.hierarchyWindowChanged += OnHierarchyWindowChanged;
+      #if UNITY_2018_1_OR_NEWER
+        EditorApplication.hierarchyChanged += OnHierarchyWindowChanged;
+      #else
+        EditorApplication.hierarchyWindowChanged += OnHierarchyWindowChanged;
+      #endif
       EditorSceneManager.sceneSaved += OnSceneSaved;
       EditorSceneManager.sceneOpened += OnSceneOpened;
       EditorSceneManager.sceneClosing += OnSceneClosing;


### PR DESCRIPTION
hierarchyWindowChanged is obsolete, and superceded by hierarchyChanged in unity 2018.1 or newer, to ensure backwards compatibility i use Platform #define directives to use the correct event based on the unity version.