### PR TITLE
Fix heartbeat spamming

### DIFF
--- a/Assets/com.vladfaust.unitywakatime/Editor/Plugin.cs
+++ b/Assets/com.vladfaust.unitywakatime/Editor/Plugin.cs
@@ -86,11 +86,13 @@ namespace WakaTime {
       File.WriteAllLines(WAKATIME_PROJECT_FILE, content);
     }
 
+    [Serializable]
     struct Response<T> {
       public string error;
       public T data;
     }
 
+    [Serializable]
     struct HeartbeatResponse {
       public string id;
       public string entity;
@@ -127,7 +129,7 @@ namespace WakaTime {
 
       var currentScene = EditorSceneManager.GetActiveScene().path;
       var file = currentScene != string.Empty
-        ? Path.Combine(Application.dataPath, currentScene.Substring("Assets/".Length))
+        ? Application.dataPath + "/" + currentScene.Substring("Assets/".Length)
         : string.Empty;
 
       var heartbeat = new Heartbeat(file, fromSave);
@@ -216,7 +218,7 @@ namespace WakaTime {
           EditorApplication.hierarchyChanged -= OnHierarchyWindowChanged;
         #else
           EditorApplication.hierarchyWindowChanged -= OnHierarchyWindowChanged;
-        #endif  
+        #endif
         EditorSceneManager.sceneSaved -= OnSceneSaved;
         EditorSceneManager.sceneOpened -= OnSceneOpened;
         EditorSceneManager.sceneClosing -= OnSceneClosing;


### PR DESCRIPTION
In Windows, Path.Combine adds a backslash instead of a forward slash, making the heartbeat entity different from the entity in _lastHeartbeat response. Then it's not possible to skip any heartbeat. I tested and the server changes all backslashes into a forward slash. (eg: "\" to "/" and "\\\\\\\" to "/"). Application.dataPath and currentScene strings look ok because they use "/" in the editor.

Also added [Serializable] to the structs because _lastHeartbeat was not being set, I believe it is required for JSON.