### PR TITLE
Fixed some compiler warnings in Plugin.cs

### DIFF
--- a/Assets/com.vladfaust.unitywakatime/Editor/Plugin.cs
+++ b/Assets/com.vladfaust.unitywakatime/Editor/Plugin.cs
@@ -87,15 +87,15 @@ namespace WakaTime {
     }
 
     struct Response<T> {
-      public string error;
-      public T data;
+      public string error = null;
+      public T data = default(T);
     }
 
     struct HeartbeatResponse {
-      public string id;
-      public string entity;
-      public string type;
-      public float time;
+      public string id = null;
+      public string entity = null;
+      public string type = null;
+      public float time = 0f;
     }
 
     struct Heartbeat {
@@ -141,7 +141,6 @@ namespace WakaTime {
 
       var request = UnityWebRequest.Post(URL_PREFIX + "users/current/heartbeats?api_key=" + _apiKey, string.Empty);
       request.uploadHandler = new UploadHandlerRaw(System.Text.Encoding.UTF8.GetBytes(heartbeatJSON));
-      request.chunkedTransfer = false;
       request.SetRequestHeader("Content-Type", "application/json");
 
       request.SendWebRequest().completed +=


### PR DESCRIPTION
One of my least favorite things about Unity packages is that all compiler warnings in the package end up in the Console... I was getting tired of WakaTime warnings showing up in my Cloud Build logs. This PR should fix all of the following warnings:

```txt
[Unity] Library/PackageCache/com.vladfaust.unitywakatime@b8a1d9f726608a3517fade7d045c7c629a57c302/Editor/Plugin.cs(144,7): warning CS0618: 'UnityWebRequest.chunkedTransfer' is obsolete: 'HTTP/2 and many HTTP/1.1 servers don't support this; we recommend leaving it set to false (default).'
[Unity] Library/PackageCache/com.vladfaust.unitywakatime@b8a1d9f726608a3517fade7d045c7c629a57c302/Editor/Plugin.cs(90,21): warning CS0649: Field 'Plugin.Response<T>.error' is never assigned to, and will always have its default value null
[Unity] Library/PackageCache/com.vladfaust.unitywakatime@b8a1d9f726608a3517fade7d045c7c629a57c302/Editor/Plugin.cs(96,21): warning CS0649: Field 'Plugin.HeartbeatResponse.entity' is never assigned to, and will always have its default value null
[Unity] Library/PackageCache/com.vladfaust.unitywakatime@b8a1d9f726608a3517fade7d045c7c629a57c302/Editor/Plugin.cs(97,21): warning CS0649: Field 'Plugin.HeartbeatResponse.type' is never assigned to, and will always have its default value null
[Unity] Library/PackageCache/com.vladfaust.unitywakatime@b8a1d9f726608a3517fade7d045c7c629a57c302/Editor/Plugin.cs(95,21): warning CS0649: Field 'Plugin.HeartbeatResponse.id' is never assigned to, and will always have its default value null
[Unity] Library/PackageCache/com.vladfaust.unitywakatime@b8a1d9f726608a3517fade7d045c7c629a57c302/Editor/Plugin.cs(98,20): warning CS0649: Field 'Plugin.HeartbeatResponse.time' is never assigned to, and will always have its default value 0
[Unity] Library/PackageCache/com.vladfaust.unitywakatime@b8a1d9f726608a3517fade7d045c7c629a57c302/Editor/Plugin.cs(91,16): warning CS0649: Field 'Plugin.Response<T>.data' is never assigned to, and will always have its default value
```