### PR TITLE
Fix native collections leak on Unity v2021+

### DIFF
--- a/Assets/com.vladfaust.unitywakatime/Editor/Plugin.cs
+++ b/Assets/com.vladfaust.unitywakatime/Editor/Plugin.cs
@@ -150,6 +150,7 @@ namespace WakaTime {
           if (request.downloadHandler.text == string.Empty) {
             Debug.LogWarning(
               "<WakaTime> Network is unreachable. Consider disabling completely if you're working offline");
+            request.Dispose();
             return;
           }
 
@@ -173,6 +174,8 @@ namespace WakaTime {
             if (_debug) Debug.Log("<WakaTime> Sent heartbeat!");
             _lastHeartbeat = response.data;
           }
+
+          request.Dispose();
         };
     }
 


### PR DESCRIPTION
Dispose was not called on the UnityWebRequest, which in newer versions of unity causes a memory leak.

disposeUploadHandlerOnDispose  defaults to true, so it will also implicitly dispose that class.
This is backwards compatible to unity 2018, when the UnityWebRequest class was introduced, as it has always implement IDisposable (see: https://github.com/Unity-Technologies/UnityCsReference/blob/2018.1/Modules/UnityWebRequest/Public/UnityWebRequest.bindings.cs)